### PR TITLE
Make the capture group optional

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -1,5 +1,5 @@
 const identifierAndValue = /^(\w*)(.*?)$/
-const capture = '(.+?)'
+const capture = '(.+?)?'
 
 /**
  * A parser for Nginx access and error log files.


### PR DESCRIPTION
Suppose you have the following `log_format` on `nginx.conf`:

```
log_format vcombined '$host:$server_port '
                     '$public_ip - $remote_user [$time_local] '
                     '$request_method "$request_path" "$query"
```

Where "query" is:
```
map $args $query {
  default $args;
}
```

If nginx receives a request with no querystring, like `https://example.com/hi`, the resulting log line will be:

```
example.com:443 127.0.0.1 - - [02/Jul/2020:18:24:44 +0000] GET "/hi" ""
```

If you try to parse that line, it'll always throw `'Line does not match the schema`, given the regex doesn't expect that the capture group might be empty.

Making the capture group optional fixes that, without causing any (at least that I could find) unintended side effects :tada: